### PR TITLE
fix(nix): fix dbname syntax

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -113,7 +113,7 @@ in
       after = [ "network.target" ] ++ optionals (cfg.createDatabaseLocally) [ "postgresql.service" ];
 
       environment = mkIf cfg.createDatabaseLocally {
-        POSTGRES_CONNECTION = "postgres://letterbox?host=/var/run/postgresql";
+        POSTGRES_CONNECTION = "postgres:///letterbox?host=/var/run/postgresql";
         CONFIG_PATH = tomlFormat.generate "letterbox-config.toml" cfg.settings;
       };
 


### PR DESCRIPTION
Apparently dbname has to be preceeded by a /. tokio-postgres didn't care
as it would just leave the dbname empty and (I assume) set it equal to
the user later on. See https://docs.rs/tokio-postgres/latest/src/tokio_postgres/config.rs.html#1099

deadpool seems to check if dbname is actually set, and as our url was
malformed, it complained.

This fixes it :D

Signed-off-by: Sefa Eyeoglu <contact@scrumplex.net>
